### PR TITLE
Fix defn

### DIFF
--- a/src/sunrise/core.cljs
+++ b/src/sunrise/core.cljs
@@ -8,7 +8,7 @@
         height (.-innerHeight js/window)]
     {:width width :height height}))
 
-(defn update-window-state
+(defn update-window-state []
   (state/update-window! (get-window-dimensions)))
 
 (.addEventListener js/window "resize" update-window-state)

--- a/src/sunrise/core.cljs
+++ b/src/sunrise/core.cljs
@@ -8,10 +8,10 @@
         height (.-innerHeight js/window)]
     {:width width :height height}))
 
-(defn update-window-state []
+(defn update-window-state! []
   (state/update-window! (get-window-dimensions)))
 
-(.addEventListener js/window "resize" update-window-state)
+(.addEventListener js/window "resize" update-window-state!)
 
-(update-window-state)
+(update-window-state!)
 (reagent/render-component [component/app-container] (.getElementById js/document "app"))


### PR DESCRIPTION
Adds the missing params array to `defn` and marks `update-window-state` as a function that alters an atom.