### PR TITLE
Move functions dealing with the dom into their own namespace

### DIFF
--- a/src/sunrise/core.cljs
+++ b/src/sunrise/core.cljs
@@ -1,17 +1,5 @@
 (ns sunrise.core
-  (:require [reagent.core :as reagent]
-            [sunrise.component :as component]
-            [sunrise.state :as state]))
+  (:require [sunrise.dom :as dom]))
 
-(defn get-window-dimensions []
-  (let [width (.-innerWidth js/window)
-        height (.-innerHeight js/window)]
-    {:width width :height height}))
+(dom/init!)
 
-(defn update-window-state! []
-  (state/update-window! (get-window-dimensions)))
-
-(.addEventListener js/window "resize" update-window-state!)
-
-(update-window-state!)
-(reagent/render-component [component/app-container] (.getElementById js/document "app"))

--- a/src/sunrise/dom.cljs
+++ b/src/sunrise/dom.cljs
@@ -1,0 +1,17 @@
+(ns sunrise.dom
+  (:require [reagent.core :as reagent]
+            [sunrise.state :as state]
+            [sunrise.component :as component]))
+
+(defn get-window-dimensions []
+  (let [width (.-innerWidth js/window)
+        height (.-innerHeight js/window)]
+    {:width width :height height}))
+
+
+(defn init! []
+  (.addEventListener js/window
+                     "resize"
+                     #(state/update-window! (get-window-dimensions)))
+  (state/update-window! (get-window-dimensions))
+  (reagent/render-component [component/app-container] (.getElementById js/document "app")))

--- a/src/sunrise/state.cljs
+++ b/src/sunrise/state.cljs
@@ -1,7 +1,7 @@
 (ns sunrise.state
   (:require [reagent.core :as reagent]))
 
-(def display-state (reagent/atom {}))
+(def display-state (reagent/atom {:window nil}))
 
 (defn update-window! [dimensions]
    (swap! display-state assoc :window dimensions))


### PR DESCRIPTION
This PR is mostly to take all the dom functions out of core. 

It also initializes the `:window` key of state, and removes the extraneous function around `(state/update-window! (get-window-dimensions))`.

